### PR TITLE
Use latest mlir, refactor relu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard to conform to")
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 
 find_package(MLIR REQUIRED CONFIG)
 

--- a/examples/tinygrad.mlir
+++ b/examples/tinygrad.mlir
@@ -24,7 +24,7 @@ func.func @main() {
     %11 = "tinygrad.div"(%10, %4) : (tensor<2x3xf64>, tensor<2x3xf64>) -> tensor<2x3xf64>
     %12 = "tinygrad.neg"(%9) : (tensor<2x3xf64>) -> tensor<2x3xf64>
     %13 = "tinygrad.gt0"(%12) : (tensor<2x3xf64>) -> tensor<2x3xi1>
-    %14 = "tinygrad.relu"(%9) :  (tensor<2x3xf64>) -> tensor<2x3xf64>
+    %14 = "tinygrad.relu"(%12) :  (tensor<2x3xf64>) -> tensor<2x3xf64>
      "tinygrad.print"(%14) : (tensor<2x3xf64>) -> ()
     return
 }

--- a/include/TinyGrad/TinyGradOps.td
+++ b/include/TinyGrad/TinyGradOps.td
@@ -14,7 +14,7 @@ movement_op (RESHAPE, PERMUTE, PAD, SHRINK, EXPAND, FLIP)  # A -> B (different s
 processing_op (CONV)                                       # A + B -> C
 */
 
-def ConstantOp : TinyGradOp<"constant", [NoSideEffect]> {
+def ConstantOp : TinyGradOp<"constant", [NoMemoryEffect]> {
   let summary = "constant";
   let description = [{
     Constant operation turns a literal into an SSA value. The data is attached
@@ -77,19 +77,19 @@ class BinaryOp<string mnemonic, list<Trait> traits = []> : TinyGradOp<mnemonic, 
 }
 
 // Binary
-def AddOp : BinaryOp<"add",   [NoSideEffect]>;
-def SubOp : BinaryOp<"sub",   [NoSideEffect]>;
-def MulOp : BinaryOp<"mul",   [NoSideEffect]>;
-def DivOp : BinaryOp<"div",   [NoSideEffect]>;
-def PowOp : BinaryOp<"pow",   [NoSideEffect]>;
-def CmpEq : BinaryOp<"cmpeq", [NoSideEffect]>;
+def AddOp : BinaryOp<"add",   [NoMemoryEffect]>;
+def SubOp : BinaryOp<"sub",   [NoMemoryEffect]>;
+def MulOp : BinaryOp<"mul",   [NoMemoryEffect]>;
+def DivOp : BinaryOp<"div",   [NoMemoryEffect]>;
+def PowOp : BinaryOp<"pow",   [NoMemoryEffect]>;
+def CmpEq : BinaryOp<"cmpeq", [NoMemoryEffect]>;
 
 // Unary
-def ReluOp : UnaryOp<"relu", [NoSideEffect]>;
-def ExpOp  : UnaryOp<"exp",  [NoSideEffect]>;
-def LogOp  : UnaryOp<"log",  [NoSideEffect]>;
-def NegOp  : UnaryOp<"neg",  [NoSideEffect]>;
-def Gt0Op  : UnaryOp<"gt0",  [NoSideEffect]>;
+def ReluOp : UnaryOp<"relu", [NoMemoryEffect]>;
+def ExpOp  : UnaryOp<"exp",  [NoMemoryEffect]>;
+def LogOp  : UnaryOp<"log",  [NoMemoryEffect]>;
+def NegOp  : UnaryOp<"neg",  [NoMemoryEffect]>;
+def Gt0Op  : UnaryOp<"gt0",  [NoMemoryEffect]>;
 
 class MovementOp<string mnemonic, list<Trait> traits = []> : TinyGradOp<mnemonic, traits>   {
   let summary = "Base class for movement tinygrad operations";
@@ -117,7 +117,7 @@ def ShrinkOp  : MovementOp<"shrink">;
 def ExpandOp  : MovementOp<"expand">;
 def FlipOp    : MovementOp<"flip">;
 
-def PrintOp : TinyGradOp<"print", [NoSideEffect]> {
+def PrintOp : TinyGradOp<"print", [NoMemoryEffect]> {
     let summary = "print operation";
     let description = [{
         The "print" builtin operation prints a given input tensor, and produces

--- a/lib/TinyGrad/LowerToLLVM.cpp
+++ b/lib/TinyGrad/LowerToLLVM.cpp
@@ -20,7 +20,7 @@
 #include "TinyGrad/TinyGradPasses.h"
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
-#include "mlir/Conversion/ArithmeticToLLVM/ArithmeticToLLVM.h"
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
@@ -30,7 +30,7 @@
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -88,7 +88,7 @@ public:
 
     // Generate a call to printf for the current element of the loop.
     auto printOp = mlir::cast<tinygrad::PrintOp>(op);
-    auto elementLoad = rewriter.create<mlir::memref::LoadOp>(loc, printOp.input(), loopIvs);
+    auto elementLoad = rewriter.create<mlir::memref::LoadOp>(loc, printOp.getInput(), loopIvs);
     rewriter.create<mlir::func::CallOp>(loc, printfRef, rewriter.getIntegerType(32),
                             mlir::ArrayRef<mlir::Value>({formatSpecifierCst, elementLoad}));
 
@@ -166,9 +166,9 @@ void TinyGradToLLVMLoweringPass::runOnOperation() {
 
   populateAffineToStdConversionPatterns(patterns);
   populateSCFToControlFlowConversionPatterns(patterns);
-  mlir::arith::populateArithmeticToLLVMConversionPatterns(typeConverter, patterns);
+  mlir::arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
   mlir::populateMathToLLVMConversionPatterns(typeConverter, patterns);
-  mlir::populateMemRefToLLVMConversionPatterns(typeConverter, patterns);
+  mlir::populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns);
   mlir::cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
   populateFuncToLLVMConversionPatterns(typeConverter, patterns);
 


### PR DESCRIPTION
- Update codebase to compile with the latest llvm-project `main` (commit eb8e1bf92b49af911d069cee4fd948faf1de102c)
- Simplify `tinygrad.relu`: because of a bug in an older version of mlir, `MaxFOP`, and `MinFOp` failed to legalize when lowering `relu`. As a workaround, `relu` was implemented as a `CmpFOp` followed by a `SelectOp`. With the new mlir version, `MaxFOp` works fine.