### PR TITLE
Implement reshape op

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # Created by https://www.toptal.com/developers/gitignore/api/c,c++,clion,macos,cmake
 # Edit at https://www.toptal.com/developers/gitignore?templates=c,c++,clion,macos,cmake
 
+*.s
+.vscode
 *.ll
 
 ### C ###

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ lli /path/to/tinygrad.ll
 - [x] GT0*
 
 ### Movement ops
-- [ ] RESHAPE
+- [x] RESHAPE
 - [ ] PERMUTE
 - [ ] PAD
 - [ ] SHRINK
@@ -79,21 +79,42 @@ $ lli /path/to/tinygrad.ll
 
 Unary op
 ```mlir
-  %0 = "tinygrad.constant"() {value = dense<[[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
-  %1 = "tinygrad.neg"(%0) : (tensor<2x3xf64>) -> tensor<2x3xf64>
-  "tinygrad.print"(%1) : (tensor<2x3xf64>) -> ()
+  func.func @main() {
+    %0 = "tinygrad.constant"() {value = dense<[[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
+    %1 = "tinygrad.neg"(%0) : (tensor<2x3xf64>) -> tensor<2x3xf64>
+    "tinygrad.print"(%1) : (tensor<2x3xf64>) -> ()
+    return
+  }
   Output:
-  [[-2.0, -2.0, -2.0], 
-  [-2.0, -2.0, -2.0]]
+  -2.0 -2.0 -2.0 
+  -2.0 -2.0 -2.0
 ```
 
 Binary op
 
 ```mlir
-  %0 = "tinygrad.constant"() {value = dense<[[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
-  %1 = "tinygrad.add"(%0, %0) : (tensor<2x3xf64>, tensor<2x3xf64>) -> tensor<2x3xf64>
-  "tinygrad.print"(%1) : (tensor<2x3xf64>) -> ()
+  func.func @main() {
+    %0 = "tinygrad.constant"() {value = dense<[[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
+    %1 = "tinygrad.add"(%0, %0) : (tensor<2x3xf64>, tensor<2x3xf64>) -> tensor<2x3xf64>
+    "tinygrad.print"(%1) : (tensor<2x3xf64>) -> ()
+    return
+  }
   Output:
-  [[4.0, 4.0, 4.0], 
-  [4.0, 4.0, 4.0]]
+  4.0 4.0 4.0 
+  4.0 4.0 4.0
+```
+
+Movement op
+
+```mlir
+  func.func @main() {
+    %0 = "tinygrad.constant"()  { value = dense<[[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]]> : tensor<2x3xf64> } : () -> tensor<2x3xf64>
+    %1 = "tinygrad.reshape"(%0) { shape = dense<[3,2]> : tensor<2xi32> } : (tensor<2x3xf64>) -> memref<3x2xf64>
+    "tinygrad.print"(%1) : (memref<3x2xf64>) -> ()
+    return
+  }
+  Output:
+  2.0 2.0
+  2.0 2.0
+  2.0 2.0
 ```

--- a/examples/tinygrad.mlir
+++ b/examples/tinygrad.mlir
@@ -25,6 +25,8 @@ func.func @main() {
     %12 = "tinygrad.neg"(%9) : (tensor<2x3xf64>) -> tensor<2x3xf64>
     %13 = "tinygrad.gt0"(%12) : (tensor<2x3xf64>) -> tensor<2x3xi1>
     %14 = "tinygrad.relu"(%12) :  (tensor<2x3xf64>) -> tensor<2x3xf64>
-     "tinygrad.print"(%14) : (tensor<2x3xf64>) -> ()
+    "tinygrad.print"(%14) : (tensor<2x3xf64>) -> ()
+    %15 = "tinygrad.reshape"(%14) { shape = dense<[3, 2]> : tensor<2xi32>} : (tensor<2x3xf64>) -> memref<3x2xf64>
+    "tinygrad.print"(%15) : (memref<3x2xf64>) -> ()
     return
 }

--- a/include/TinyGrad/TinyGradOps.td
+++ b/include/TinyGrad/TinyGradOps.td
@@ -110,7 +110,29 @@ class MovementOp<string mnemonic, list<Trait> traits = []> : TinyGradOp<mnemonic
   );
 }
 
-def ReshapeOp : MovementOp<"reshape">;
+def ReshapeOp : MovementOp<"reshape"> {
+  let summary = "Reshape movement operation";
+  let description = [{
+    Reshapes the input tensor to a shape defined in 'shape' attribute.
+
+    ```mlir
+      %0 = "tinygrad.constant"()
+      { value = dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf64> }
+      : () -> tensor<2x3xf64>
+      %1 = "tinygrad.reshape"(%0)
+      { shape = dense<[3,2]> : tensor<2xi32> }
+      : (tensor<2x3xf64>) -> tensor<3x2xf64>
+    ```
+  }];
+
+  let arguments = (ins
+    I32ElementsAttr:$shape,
+    AnyTypeOf<[F64Tensor, F64MemRef]>:$operand
+  );
+
+  let results = (outs AnyTypeOf<[F64Tensor, F64MemRef]>);
+}
+
 def PermuteOp : MovementOp<"permute">;
 def PadOp     : MovementOp<"pad">;
 def ShrinkOp  : MovementOp<"shrink">;


### PR DESCRIPTION
Implement `tinygrad::ReshapeOp` and lower to `mlir::memref::ReshapeOp`

Shape is defined as an attribute of `tinygrad::ReshapeOp`. The attribute is materialized by allocating a `memref`, and storing the shape in it.