### PR TITLE
Simplify shape attribute conversion to memref

### DIFF
--- a/examples/tinygrad.mlir
+++ b/examples/tinygrad.mlir
@@ -26,7 +26,7 @@ func.func @main() {
     %13 = "tinygrad.gt0"(%12) : (tensor<2x3xf64>) -> tensor<2x3xi1>
     %14 = "tinygrad.relu"(%12) :  (tensor<2x3xf64>) -> tensor<2x3xf64>
     "tinygrad.print"(%14) : (tensor<2x3xf64>) -> ()
-    %15 = "tinygrad.reshape"(%14) { shape = dense<[3, 2]> : tensor<2xi32>} : (tensor<2x3xf64>) -> memref<3x2xf64>
-    "tinygrad.print"(%15) : (memref<3x2xf64>) -> ()
+    %15 = "tinygrad.reshape"(%14) { shape = dense<[6]> : tensor<1xi32>} : (tensor<2x3xf64>) -> memref<6xf64>
+    "tinygrad.print"(%15) : (memref<6xf64>) -> ()
     return
 }


### PR DESCRIPTION
`ConstantOpLowering` converts `DenseElementsAttr` to `memref` by a recursive function to traverse all the elements and store them at the correct multidimensional indices. For `tinygrad::ReshapeOp` however, we don't need that, as the `shape` attribute will always be one dimensional. Thus the loop to store the `shape` attribute elements to a `memref` has been simplified.